### PR TITLE
DCN-103 - Fix setValue (initialValue), output only compilation errors…

### DIFF
--- a/client/custom-element-api-mock/index.ts
+++ b/client/custom-element-api-mock/index.ts
@@ -72,7 +72,7 @@ class FakeCustomElement implements ICustomElement {
     if (DevKit) {
         DevKit.storeValue(value);
     }
-    (window as any).customElement.value = value;
+    (window as any).customElement.initialValue = value;
   }
 
   public init(cb: (element: ICustomElementData, context: ICustomElementContext) => void): void {

--- a/server/index.ts
+++ b/server/index.ts
@@ -32,9 +32,7 @@ const logCompiledEntryPoint = (stats: Stats): void => {
 
 const logCompilationErrors = (stats: Stats): void => {
   console.log('\n\nCompilation failed:\n\n');
-  console.log((typeof stats.toJson === 'function') ? stats.toJson({
-    errors: true,
-  }) : stats);
+  console.log((typeof stats.toJson === 'function') ? stats.toJson('errors-only') : stats);
 };
 
 const buildOnceAndOutput = async (customElementsInformation: ReadonlyArray<CustomElementInformation>, args: CmdArguments) => {


### PR DESCRIPTION
### Motivation

There was a mistake in setValue, it should have modified the initialValue so that it is used properly when custom element is refreshed

There is also a minor adjustment to webpack so that compilation errors can be easily found in console (most of the output is now ommited)

### How to test

Probably no need to, but just for sure try some custom element with / without initial value and how it behaves together with refresh

Also, when there is a compilation error, the console should no longer contain the long output with useless information, just the error and warnings